### PR TITLE
Added different colors for different levels

### DIFF
--- a/home/templates/dashboard/index.html
+++ b/home/templates/dashboard/index.html
@@ -184,7 +184,6 @@
                         <th scope="col"></th>
                         </tr>
                     </thead>
-                    
                     {% for issue in issues %}
                         <tbody class="bg-light">
                         <tr class="align-middle text-center">
@@ -194,7 +193,20 @@
                             <td>{{ issue.project.domain }}</td>
                             <td>@{{ issue.mentor }}</td>
                             <td>{{ issue.points }}</td>
-                            <td><a class="btn btn-rounded btn-info mt-0" data-mdb-toggle="tooltip" title="Level">{{ issue.get_level_display }}</a></td>
+                            <td>
+                                <a class="btn btn-rounded 
+                                    {% if issue.get_level_display == 'Hard' %}
+                                        btn-danger
+                                    {% elif issue.get_level_display == 'Medium' %}
+                                        btn-warning
+                                    {% elif issue.get_level_display == 'Easy' %}
+                                        btn-success
+                                    {% else %}
+                                        btn-info
+                                    {% endif %}
+                                    mt-0" data-mdb-toggle="tooltip" title="Level">{{ issue.get_level_display }}
+                                </a>
+                            </td>
                             <td>
                                 {% if issue.is_restricted %}
                                 <button data-mdb-toggle="tooltip"


### PR DESCRIPTION
changed the home/templates/dashboard/index.html file 
<!-- Dynamically set the button color based on issue level -->
            <td>
                <a class="btn btn-rounded 
                    {% if issue.get_level_display == 'Hard' %}
                        btn-danger
                    {% elif issue.get_level_display == 'Medium' %}
                        btn-warning
                    {% elif issue.get_level_display == 'Easy' %}
                        btn-success
                    {% else %}
                        btn-info
                    {% endif %}
                    mt-0" data-mdb-toggle="tooltip" title="Level">{{ issue.get_level_display }}
                </a>
            </td>
![Screenshot 2024-10-11 113122](https://github.com/user-attachments/assets/961d7773-621d-4eb7-ae26-0236b2a18659)
added screenshot for clearance please let me know if there will be any issues 